### PR TITLE
Add shell script helpers for Mac and Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh		text eol=lf

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ You'll need PowerShell 5+ installed, or PowerShell Core.  To install the depende
 setup.cmd
 ```
 
+If you're in Linux or Mac, you can use the shell script instead (assuming you've got PowerShell Core installed already):
+
+```
+./setup.sh
+```
+
 Or if you're already in PowerShell:
 
 ```
@@ -34,6 +40,14 @@ psakefile.ps1
 setup.cmd
 setup.ps1
 tools/
+```
+
+To support Linux and Mac builds, also copy:
+
+```
+.gitattributes
+psake.sh
+setup.sh
 ```
 
 Then you should customize `setup.ps1` to include anything else you need for your build, and customize `psakefile.ps1` to add any other useful tasks you need.

--- a/psake.sh
+++ b/psake.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env pwsh
+
+# Helper script for those who want to run psake from cmd.exe
+
+invoke-psake @args; if ($psake.build_success -eq $false) { exit 1 } else { exit 0 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+
+& ./setup.ps1


### PR DESCRIPTION
Added helper scripts for Mac and Linux that *should* launch PowerShellCore.  I tested it out on Linux and it works, but I don't have a Mac to test on.

Updated the README with notes as well.

Fixes #4 