### PR TITLE
Apply changes that were submitted to Contoso University Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -327,6 +327,3 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder
 .mfractor/
-
-# the generated props file
-src/Directory.Build.props

--- a/build/general-helpers.ps1
+++ b/build/general-helpers.ps1
@@ -1,22 +1,4 @@
 ﻿
-function Set-Project-Properties($targetVersion) {
-    $copyright = $(get-copyright)
-
-    write-host "$product $targetVersion"
-    write-host $copyright
-
-    set-regenerated-file "$pwd/Directory.Build.props" @"
-<Project>
-    <PropertyGroup>
-        <Product>$product</Product>
-        <Version>$targetVersion</Version>
-        <Copyright>$copyright</Copyright>
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
-</Project>
-"@
-}
-
 function Get-Copyright {
     $date = Get-Date
     $year = $date.Year
@@ -27,7 +9,7 @@ function Get-Copyright {
 function Publish-Project {
     $project = Split-Path $pwd -Leaf
     Write-Host "Publishing $project"
-    dotnet publish --configuration $configuration --no-restore --output $publish/$project /nologo
+    dotnet publish --configuration $configuration --no-build --output $publish/$project /nologo
 }
 
 function Set-Regenerated-File($path, $newContent) {

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -26,8 +26,7 @@ task Test -depends Compile -description "Run unit tests" {
 }
   
 task Compile -depends Info -description "Compile the solution" {
-    exec { set-project-properties $version } -workingDirectory src
-    exec { dotnet build --configuration $configuration /nologo } -workingDirectory src
+    exec { dotnet build --configuration $configuration --nologo -p:"Product=$($product)" -p:"Copyright=$(get-copyright)" -p:"Version=$($version)" } -workingDirectory src
 }
 
 task Publish -depends Compile -description "Publish the primary projects for distribution" {

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,8 +1,0 @@
-﻿using System.Reflection;
-
-[assembly: AssemblyVersion("2.0")]
-[assembly: AssemblyFileVersion("2.0")]
-[assembly: AssemblyCopyright("© 2018 Headspring")]
-[assembly: AssemblyProduct("Sample Build Scripts")]
-[assembly: AssemblyCompany("Headspring")]
-[assembly: AssemblyInformationalVersion("2.0-dev")]


### PR DESCRIPTION
When generating the version number in the build process, apply it using msbuild parameters instead of creating a `Directory.build.props` file. This way, the user can create their own props files without colliding with the build process.