### PR TITLE
Tech 91 Added MinVer to sample project and updated build script

### DIFF
--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -8,7 +8,7 @@ properties {
     $yearInitiated = '2018'
     $projectRootDirectory = "$(resolve-path .)"
     $publish = "$projectRootDirectory/Publish"
-	$artifact = "$projectRootDirectory/Artifacts"
+	$artifacts = "$projectRootDirectory/Artifacts"
     $testResults = "$projectRootDirectory/TestResults"
 }
 
@@ -36,14 +36,15 @@ task Publish -depends Compile -description "Publish the primary projects for dis
 }
 
 task Package -depends Compile -description "Package the primary project into Nuget package with version number" {
-	remove-directory-silently $artifact
-    exec { dotnet pack --configuration $configuration --nologo -p:"Product=$($product)" -p:"Copyright=$(get-copyright)" -p:"Version=$($version)" } -workingDirectory src
+	remove-directory-silently $artifacts
+    exec { dotnet pack --configuration $configuration --nologo -p:"Product=$($product)" -p:"Copyright=$(get-copyright)" -p:"Version=$($version)" -o:$artifacts} -workingDirectory src
 }
   
 task Clean -description "Clean out all the binary folders" {
     exec { dotnet clean --configuration $configuration /nologo } -workingDirectory src
     remove-directory-silently $publish
     remove-directory-silently $testResults
+    remove-directory-silently $artifacts
 }
   
 task ? -alias help -description "Display help content and possible targets" {

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -8,6 +8,7 @@ properties {
     $yearInitiated = '2018'
     $projectRootDirectory = "$(resolve-path .)"
     $publish = "$projectRootDirectory/Publish"
+	$artifact = "$projectRootDirectory/Artifacts"
     $testResults = "$projectRootDirectory/TestResults"
 }
 
@@ -32,6 +33,11 @@ task Compile -depends Info -description "Compile the solution" {
 task Publish -depends Compile -description "Publish the primary projects for distribution" {
     remove-directory-silently $publish
     exec { publish-project } -workingDirectory src/Sample1.NetCore
+}
+
+task Package -depends Compile -description "Package the primary project into Nuget package with version number" {
+	remove-directory-silently $artifact
+    exec { dotnet pack --configuration $configuration --nologo -p:"Product=$($product)" -p:"Copyright=$(get-copyright)" -p:"Version=$($version)" } -workingDirectory src
 }
   
 task Clean -description "Clean out all the binary folders" {

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -8,7 +8,7 @@ properties {
     $yearInitiated = '2018'
     $projectRootDirectory = "$(resolve-path .)"
     $publish = "$projectRootDirectory/Publish"
-	$artifacts = "$projectRootDirectory/Artifacts"
+    $artifacts = "$projectRootDirectory/Artifacts"
     $testResults = "$projectRootDirectory/TestResults"
 }
 
@@ -36,7 +36,7 @@ task Publish -depends Compile -description "Publish the primary projects for dis
 }
 
 task Package -depends Compile -description "Package the primary project into Nuget package with version number" {
-	remove-directory-silently $artifacts
+    remove-directory-silently $artifacts
     exec { dotnet pack --configuration $configuration --nologo -p:"Product=$($product)" -p:"Copyright=$(get-copyright)" -p:"Version=$($version)" -o:$artifacts} -workingDirectory src
 }
   

--- a/src/Sample1.NetCore/Sample1.NetCore.csproj
+++ b/src/Sample1.NetCore/Sample1.NetCore.csproj
@@ -4,4 +4,11 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This change adds MinVer to the sample project. The updates the the build script will name the output package according to the rules MinVer follows. Reference: MinVer: https://github.com/adamralph/minver#can-i-include-build-metadata-in-the-version for 

Notes: 
* The branch has a tag of 0.0.3 which will come in handy later when testing
* I kept Package command separate from default build command. 
* Nuget package is created in Artifacts folder
* Artifacts folder gets removed on clean

Testing:
1. Tagged commit - Run Clean, Build, then Package. The expected output should be a nuget package in Artifacts folder named "sample-build-script\Artifacts\Sample1.NetCore.**0.0.3**.nupkg"
2. Create commit (I just added a space to the psake file locally) then ran ".\psake.cmd Package"  The new package name is: "sample-build-script\Artifacts\Sample1.NetCore.**0.0.4-alpha.0.1**.nupkg"  This is because a version tag of 0.0.3 was found, and height is added = 0.0.4 then the default prerelease was added + the height see MinVer docs.

The next steps would be to add to the betterway docs. 
 